### PR TITLE
Typescript

### DIFF
--- a/examples/nextjs/package.json
+++ b/examples/nextjs/package.json
@@ -9,21 +9,20 @@
     "lint": "next lint"
   },
   "dependencies": {
+    "@brizy/docs-react": "*",
     "next": "^13.4.1",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
-    "ui": "*",
-    "@brizy/docs-react": "*"
+    "ui": "*"
   },
   "devDependencies": {
+    "@brizy/eslint-config": "*",
     "@brizy/prettier-config": "*",
     "@types/node": "^17.0.12",
     "@types/react": "^18.0.22",
     "@types/react-dom": "^18.0.7",
     "autoprefixer": "^10.4.14",
     "eslint-config-next": "^13.4.1",
-    "@brizy/eslint-config": "*",
-    "tsconfig": "*",
-    "typescript": "^4.5.3"
+    "@brizy/tsconfig": "*"
   }
 }

--- a/examples/nextjs/tsconfig.json
+++ b/examples/nextjs/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "tsconfig/nextjs.json",
+  "extends": "@brizy/tsconfig/nextjs.json",
   "compilerOptions": {
     "plugins": [{ "name": "next" }],
     "strictNullChecks": true,

--- a/package-lock.json
+++ b/package-lock.json
@@ -48,13 +48,12 @@
       "devDependencies": {
         "@brizy/eslint-config": "*",
         "@brizy/prettier-config": "*",
+        "@brizy/tsconfig": "*",
         "@types/node": "^17.0.12",
         "@types/react": "^18.0.22",
         "@types/react-dom": "^18.0.7",
         "autoprefixer": "^10.4.14",
-        "eslint-config-next": "^13.4.1",
-        "tsconfig": "*",
-        "typescript": "^4.5.3"
+        "eslint-config-next": "^13.4.1"
       }
     },
     "examples/nextjs/node_modules/@types/node": {
@@ -62,19 +61,6 @@
       "resolved": "https://registry.npmjs.org/@types/node/-/node-17.0.45.tgz",
       "integrity": "sha512-w+tIMs3rq2afQdsPJlODhoUEKzFP1ayaoyl1CcnwtIlsVe7K7bA1NGm4s3PraqTLlXnbIN84zuBlxBWo1u9BLw==",
       "dev": true
-    },
-    "examples/nextjs/node_modules/typescript": {
-      "version": "4.9.5",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.5.tgz",
-      "integrity": "sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==",
-      "dev": true,
-      "bin": {
-        "tsc": "bin/tsc",
-        "tsserver": "bin/tsserver"
-      },
-      "engines": {
-        "node": ">=4.2.0"
-      }
     },
     "node_modules/@alloc/quick-lru": {
       "version": "5.2.0",
@@ -9616,10 +9602,6 @@
       "optional": true,
       "peer": true
     },
-    "node_modules/tsconfig": {
-      "resolved": "packages/tsconfig",
-      "link": true
-    },
     "node_modules/tsconfig-paths": {
       "version": "3.14.2",
       "resolved": "https://registry.npmjs.org/tsconfig-paths/-/tsconfig-paths-3.14.2.tgz",
@@ -10265,25 +10247,12 @@
       },
       "devDependencies": {
         "@brizy/eslint-config": "*",
+        "@brizy/tsconfig": "*",
         "@swc/core": "^1.3.66",
         "rimraf": "^5.0.1",
         "swc-loader": "^0.2.3",
-        "tsconfig": "*",
-        "typescript": "^4.5.2",
         "webpack": "^5.85.1",
         "webpack-cli": "^5.1.4"
-      }
-    },
-    "packages/assetManager/node_modules/typescript": {
-      "version": "4.9.5",
-      "dev": true,
-      "license": "Apache-2.0",
-      "bin": {
-        "tsc": "bin/tsc",
-        "tsserver": "bin/tsserver"
-      },
-      "engines": {
-        "node": ">=4.2.0"
       }
     },
     "packages/documentation": {
@@ -10293,6 +10262,7 @@
       },
       "devDependencies": {
         "@brizy/eslint-config": "*",
+        "@brizy/tsconfig": "*",
         "@svgr/webpack": "^8.0.1",
         "@types/react": "^18.2.0",
         "@types/react-dom": "^18.2.0",
@@ -10304,23 +10274,8 @@
         "postcss-loader": "^7.3.3",
         "rimraf": "^5.0.1",
         "tailwindcss": "^3.3.2",
-        "tsconfig": "*",
-        "typescript": "^4.5.2",
         "util": "^0.12.5",
         "webpack": "^5.85.1"
-      }
-    },
-    "packages/documentation/node_modules/typescript": {
-      "version": "4.9.5",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.5.tgz",
-      "integrity": "sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==",
-      "dev": true,
-      "bin": {
-        "tsc": "bin/tsc",
-        "tsserver": "bin/tsserver"
-      },
-      "engines": {
-        "node": ">=4.2.0"
       }
     },
     "packages/eslint-config": {
@@ -10357,7 +10312,23 @@
     "packages/tsconfig": {
       "name": "@brizy/tsconfig",
       "version": "0.0.0",
-      "license": "MIT"
+      "license": "MIT",
+      "devDependencies": {
+        "typescript": "^5.1.6"
+      }
+    },
+    "packages/tsconfig/node_modules/typescript": {
+      "version": "5.1.6",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.1.6.tgz",
+      "integrity": "sha512-zaWCozRZ6DLEWAWFrVDz1H6FVXzUSfTy5FUMWsQlU8Ym5JP9eO4xkTIROFCQvhQf61z6O/G6ugw3SgAnvvm+HA==",
+      "dev": true,
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
     },
     "packages/ui": {
       "version": "1.0.0",
@@ -10371,24 +10342,11 @@
       },
       "devDependencies": {
         "@brizy/eslint-config": "*",
+        "@brizy/tsconfig": "*",
         "@types/react": "^18.2.0",
         "@types/react-dom": "^18.2.0",
         "rimraf": "^5.0.1",
-        "tsconfig": "*",
-        "typescript": "^4.5.2",
         "webpack": "^5.85.1"
-      }
-    },
-    "packages/ui/node_modules/typescript": {
-      "version": "4.9.5",
-      "dev": true,
-      "license": "Apache-2.0",
-      "bin": {
-        "tsc": "bin/tsc",
-        "tsserver": "bin/tsserver"
-      },
-      "engines": {
-        "node": ">=4.2.0"
       }
     }
   }

--- a/packages/assetManager/package.json
+++ b/packages/assetManager/package.json
@@ -17,8 +17,7 @@
     "@brizy/eslint-config": "*",
     "rimraf": "^5.0.1",
     "swc-loader": "^0.2.3",
-    "tsconfig": "*",
-    "typescript": "^4.5.2",
+    "@brizy/tsconfig": "*",
     "webpack": "^5.85.1",
     "webpack-cli": "^5.1.4"
   },

--- a/packages/assetManager/tsconfig.json
+++ b/packages/assetManager/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "tsconfig/base.json",
+  "extends": "@brizy/tsconfig/base.json",
   "compilerOptions": {
     "baseUrl": "src",
     "outDir": "dist"

--- a/packages/documentation/package.json
+++ b/packages/documentation/package.json
@@ -27,8 +27,7 @@
     "postcss-loader": "^7.3.3",
     "rimraf": "^5.0.1",
     "tailwindcss": "^3.3.2",
-    "tsconfig": "*",
-    "typescript": "^4.5.2",
+    "@brizy/tsconfig": "*",
     "util": "^0.12.5",
     "webpack": "^5.85.1"
   },

--- a/packages/documentation/src/welcome/index.tsx
+++ b/packages/documentation/src/welcome/index.tsx
@@ -23,7 +23,7 @@ export const Welcome = ({ href }: Props): ReactElement => {
         Welcome to Brizy
       </div>
       <div className="text-center text-[15px] font-light pb-[50px] leading-[24px] lg:text-[20px] lg:w-[820px] lg:leading-[38px]">
-        To integrate our template on Verce please click on{" "}
+        To integrate our template on Vercel please click on{" "}
         <span className="font-bold text-oceanBlue">connect</span> button to
         receive the API_KEY.
       </div>

--- a/packages/documentation/tsconfig.json
+++ b/packages/documentation/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "tsconfig/react-library.json",
+  "extends": "@brizy/tsconfig/react-library.json",
   "compilerOptions": {
     "baseUrl": "src",
     "outDir": "dist"

--- a/packages/tsconfig/package.json
+++ b/packages/tsconfig/package.json
@@ -5,5 +5,8 @@
   "license": "MIT",
   "publishConfig": {
     "access": "public"
+  },
+  "devDependencies": {
+    "typescript": "^5.1.6"
   }
 }

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -24,8 +24,7 @@
     "@types/react-dom": "^18.2.0",
     "@brizy/eslint-config": "*",
     "rimraf": "^5.0.1",
-    "tsconfig": "*",
-    "typescript": "^4.5.2",
+    "@brizy/tsconfig": "*",
     "webpack": "^5.85.1"
   }
 }

--- a/packages/ui/tsconfig.json
+++ b/packages/ui/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "tsconfig/react-library.json",
+  "extends": "@brizy/tsconfig/react-library.json",
   "compilerOptions": {
     "baseUrl": "src",
     "outDir": "dist"


### PR DESCRIPTION
Typescript upgraded from 4.5.x to latest version - 5.1.6

*Refactor: Now not need to install typescript separately in each project/package. Just install @brizy/tsconfig, which depends of TS 5.1.6